### PR TITLE
Add conversation history feature backed by localStorage

### DIFF
--- a/apps/docs/adr/0052-conversation-history-local-storage.md
+++ b/apps/docs/adr/0052-conversation-history-local-storage.md
@@ -1,0 +1,157 @@
+# 0052 – 会話履歴機能の実装（LocalStorage永続化）
+
+## 背景 / Context
+
+これまでチャット画面のメッセージはコンポーネントのuseState内にのみ保持されており、ページを離れたりブラウザを閉じたりすると会話が失われていた。ナビゲーションメニューには「チャット履歴」へのリンク（`/history`）が既に用意されていたが、実体となるページや会話保存の仕組みは未実装だった。
+
+---
+
+## 決定 / Decision
+
+`bookmark-context.tsx`と同じReact Context + LocalStorageのパターンで会話履歴を管理する`ConversationProvider`を新設し、チャット画面のメッセージ変化を自動的に会話単位で永続化する。あわせて`/history`ページを実装し、過去の会話一覧の閲覧・再開・削除を可能にする。
+
+---
+
+## 理由 / Rationale
+
+- 既存のブックマーク機能と同じ設計パターンを踏襲することで、実装コストと学習コストを抑えられる
+- 外部データベースや認証機能を追加せずに、要件である「一旦LocalStorageに保存」を満たせる
+- チャット画面と履歴画面をContextで疎結合に連携でき、既存のチャットUIへの変更を最小限にできる
+
+---
+
+## 実装詳細 / Implementation Notes
+
+### 1. 会話Context管理システムの構築
+
+```tsx
+// lib/conversation-context.tsx
+export interface Conversation {
+  id: string;
+  title: string;
+  messages: Message[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ConversationContextType extends ConversationState {
+  activeConversationId: string | null;
+  setActiveConversationId: (id: string | null) => void;
+  createConversation: (messages: Message[]) => Conversation;
+  saveMessages: (id: string, messages: Message[]) => void;
+  deleteConversation: (id: string) => void;
+  getConversation: (id: string) => Conversation | undefined;
+}
+```
+
+理由:
+- チャットの`Message`型をこのファイルに集約し、`page.tsx`と`/history`ページで共通利用できるようにした
+- `bookmark-context.tsx`と同様にuseReducerでイミュータブルな状態更新を行う
+
+### 2. LocalStorage読み込みタイミングの調整（水和ミスマッチ回避）
+
+```tsx
+// 初期状態はSSRと同じ空配列にしておき、マウント後にLocalStorageから読み込む
+const [state, dispatch] = useReducer(conversationReducer, {
+  conversations: [],
+  isLoaded: false,
+});
+
+useEffect(() => {
+  dispatch({ type: "LOAD_CONVERSATIONS", payload: loadFromLocalStorage() });
+}, []);
+```
+
+理由:
+- useReducerの初期化関数で同期的にLocalStorageを読み込むと、サーバー側でレンダリングされたHTML（常に空配列）とクライアント初回レンダリングの内容が食い違い、`/history`ページで水和（hydration）ミスマッチが発生することを確認した
+- `bookmark-context.tsx`と同じ「マウント後にuseEffectで読み込む」方式に統一し、`isLoaded`フラグで読み込み完了を子コンポーネントに伝搬できるようにした
+
+### 3. チャット画面での会話の自動保存・復元
+
+```tsx
+// app/page.tsx
+useEffect(() => {
+  if (!isConversationsLoaded || hasInitializedConversationRef.current) return;
+  hasInitializedConversationRef.current = true;
+
+  const requestedId = new URLSearchParams(window.location.search).get("conversation");
+  const idToLoad = requestedId || activeConversationId;
+  const existing = idToLoad ? getConversation(idToLoad) : undefined;
+
+  if (existing) {
+    setMessages(existing.messages);
+    setConversationId(existing.id);
+    setActiveConversationId(existing.id);
+  } else {
+    const created = createConversation(messagesRef.current);
+    setConversationId(created.id);
+    setActiveConversationId(created.id);
+  }
+}, [isConversationsLoaded, activeConversationId, getConversation, createConversation, setActiveConversationId]);
+
+useEffect(() => {
+  if (!conversationId) return;
+  saveMessages(conversationId, messages);
+  // saveMessagesはContextの再レンダリングのたびに参照が変わるため、
+  // 依存配列に含めると無限ループになる。messages変化時のみ実行する
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [conversationId, messages]);
+```
+
+理由:
+- `isConversationsLoaded`（Contextの読み込み完了フラグ）を待ってから初期化することで、LocalStorageの内容が反映される前に新規会話を作成してしまう競合を防止した
+- `hasInitializedConversationRef`で初期化処理を一度だけに限定し、Contextの関数参照が変わるたびに再実行されないようにした
+- メッセージ変化の自動保存はuseEffectの依存配列を意図的に絞り、Context関数の参照変化による無限ループを回避した
+
+### 4. 履歴一覧ページの実装
+
+```tsx
+// app/history/page.tsx
+const handleOpen = (id: string) => {
+  router.push(`/?conversation=${id}`);
+};
+```
+
+理由:
+- 既存のチャット画面（`/`）をそのまま再利用し、クエリパラメータで会話を指定する方式にすることでルーティングを簡素化した
+- `saved-phrases/page.tsx`と同様のカード型リストUIに統一し、タイトル・最終更新日時・メッセージ件数・削除ボタンを表示する
+
+---
+
+## 影響 / Consequences
+
+- チャットを離れても会話が保持され、`/history`から過去の会話を再開できるようになった
+- チャット画面に「新しい会話」ボタン（設定メニュー内）を追加したため、現在の会話を保存した状態で新規会話を開始できる
+- 将来的にバックエンドへ移行する場合も、Context層のインターフェースを保ったままLocalStorage実装部分のみ差し替え可能な設計にしている
+
+---
+
+## 言語的・技術的なポイント
+
+- LocalStorageを使うClient ComponentをNext.js App Routerで扱う際は、SSR結果と一致させるためマウント後のuseEffectで読み込む必要がある（同期的なuseReducer初期化はhydrationミスマッチの原因になる）
+- Context内の関数はレンダリングのたびに新しい参照になるため、それをuseEffectの依存配列に含めると意図しない無限ループを招きやすい
+
+---
+
+## Q&A / 技術理解のためのポイント
+
+### Q1: なぜuseReducerの初期化関数で同期的にLocalStorageを読み込まなかったのか？
+
+**Q: ブックマーク機能より先に会話データを使う必要があるなら、同期的に読み込んだ方が確実では？**
+
+**A: 実際に同期初期化を試したところ、`/history`ページでSSR結果とクライアント初回レンダリングが一致せず、Reactのhydrationミスマッチ警告が発生した。既存の`bookmark-context.tsx`と同じ非同期読み込み方式に合わせ、代わりに`isLoaded`フラグで読み込み完了を子コンポーネントに伝える設計に変更した。**
+
+### Q2: チャット画面の初期化処理はなぜ一度きりのuseEffectでは実装できなかったのか？
+
+**Q: マウント時に1回だけ実行するなら`useEffect(() => {...}, [])`で十分では？**
+
+**A: 空の依存配列だと、ConversationProviderのLocalStorage読み込みが完了する前にチャット画面側の初期化処理が走ってしまい、まだ空の会話一覧を見て新規会話を作成してしまう競合があった。`isLoaded`フラグを依存配列に含め、読み込み完了後に一度だけ実行されるよう`hasInitializedConversationRef`で制御する方式にした。**
+
+---
+
+## 参考 / References
+
+- 0041-bookmark-integration-localstorage-persistence.md - Context + LocalStorageによる永続化パターンの前例
+- 0039-bookmark-page-implementation.md - 一覧ページのUIパターンの前例
+
+---

--- a/apps/web/app/history/page.tsx
+++ b/apps/web/app/history/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useConversation } from "@/lib/conversation-context";
+import { Button } from "@/components/ui/button";
+import { MessageCircle, Trash2 } from "lucide-react";
+
+export default function HistoryPage() {
+  const { conversations, deleteConversation } = useConversation();
+  const router = useRouter();
+
+  // 直近に更新された会話が上に来るように並び替える
+  const sortedConversations = [...conversations].sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  );
+
+  const formatTimestamp = (isoString: string) =>
+    new Date(isoString).toLocaleString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+
+  const handleOpen = (id: string) => {
+    router.push(`/?conversation=${id}`);
+  };
+
+  const handleDelete = (event: React.MouseEvent, id: string) => {
+    event.stopPropagation();
+    deleteConversation(id);
+  };
+
+  return (
+    <div className="flex flex-col h-screen max-w-4xl mx-auto bg-white">
+      <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+        {sortedConversations.length === 0 ? (
+          <div className="text-center py-8 sm:py-12 px-4">
+            <div className="text-gray-400 mb-4">
+              <MessageCircle className="h-10 w-10 sm:h-12 sm:w-12 mx-auto" />
+            </div>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              チャット履歴がありません
+            </h3>
+            <p className="text-gray-500 text-sm sm:text-base">
+              チャットを開始すると、ここに履歴が表示されます
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {sortedConversations.map((conversation) => {
+              const lastMessage =
+                conversation.messages[conversation.messages.length - 1];
+              return (
+                <div
+                  key={conversation.id}
+                  className="rounded-lg border border-gray-200 bg-white p-4 sm:p-5 transition-all duration-200 hover:shadow-md hover:border-blue-300 cursor-pointer"
+                  onClick={() => handleOpen(conversation.id)}
+                >
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <h3 className="font-semibold text-gray-900 truncate">
+                        {conversation.title}
+                      </h3>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-9 w-9 p-0 flex-shrink-0 hover:bg-red-100 text-red-600 touch-manipulation"
+                        onClick={(event) => handleDelete(event, conversation.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    {lastMessage && (
+                      <p className="text-sm text-gray-600 truncate">
+                        {lastMessage.content}
+                      </p>
+                    )}
+                    <div className="flex items-center justify-between text-xs text-gray-500">
+                      <span>{formatTimestamp(conversation.updatedAt)}</span>
+                      <span>{conversation.messages.length}件のメッセージ</span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import { AppLayout } from "@/components/ui/app-layout";
 import { BookmarkProvider } from "@/lib/bookmark-context";
+import { ConversationProvider } from "@/lib/conversation-context";
 import { ServiceWorkerRegister } from "@/components/service-worker-register";
 
 const geistSans = localFont({
@@ -42,10 +43,12 @@ export default function RootLayout({
     <html lang="ja">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <BookmarkProvider>
-          <AppLayout>
-            {children}
-          </AppLayout>
-          <ServiceWorkerRegister />
+          <ConversationProvider>
+            <AppLayout>
+              {children}
+            </AppLayout>
+            <ServiceWorkerRegister />
+          </ConversationProvider>
         </BookmarkProvider>
       </body>
     </html>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -4,6 +4,7 @@ import type React from "react";
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useBookmark, createSavedPhraseFromMessage } from "@/lib/bookmark-context";
+import { useConversation, type Message } from "@/lib/conversation-context";
 import { ttsPlayer } from "@/lib/audio-player";
 import { Button } from "@/components/ui/button";
 import { CorrectionDisplay } from "@/components/ui/correction-display";
@@ -22,32 +23,32 @@ import {
   Bookmark,
   Languages,
   MessageCircle,
+  MessageSquarePlus,
   Briefcase,
   Newspaper,
 } from "lucide-react";
 
-interface Message {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  correctedContent?: string;
-  translatedContent?: string;
-  timestamp: string;
-  type?: "news" | "chat";
-  currentIndex?: number;
-  totalStories?: number;
-  originalContent?: string;
-}
+const createInitialMessages = (): Message[] => [
+  {
+    id: "initial",
+    role: "assistant",
+    content: "Hey! What should we do?",
+    timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }),
+  },
+];
 
 export default function ChatUI() {
-  const [messages, setMessages] = useState<Message[]>([
-    {
-      id: "initial",
-      role: "assistant",
-      content: "Hey! What should we do?",
-      timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }),
-    },
-  ]);
+  const [messages, setMessages] = useState<Message[]>(createInitialMessages);
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const hasInitializedConversationRef = useRef(false);
+  const {
+    isLoaded: isConversationsLoaded,
+    activeConversationId,
+    setActiveConversationId,
+    createConversation,
+    saveMessages,
+    getConversation,
+  } = useConversation();
 
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
@@ -629,6 +630,61 @@ export default function ChatUI() {
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  // 会話履歴の初期化: LocalStorageの読み込み完了を待ってから、
+  // URLの?conversation=<id>、なければ直前に開いていた会話、
+  // どちらもなければ新規会話を復元・作成する（一度だけ実行）
+  useEffect(() => {
+    if (!isConversationsLoaded || hasInitializedConversationRef.current) return;
+    hasInitializedConversationRef.current = true;
+
+    const requestedId = new URLSearchParams(window.location.search).get(
+      "conversation"
+    );
+    const idToLoad = requestedId || activeConversationId;
+    const existing = idToLoad ? getConversation(idToLoad) : undefined;
+
+    if (existing) {
+      setMessages(existing.messages);
+      setConversationId(existing.id);
+      setActiveConversationId(existing.id);
+    } else {
+      const created = createConversation(messagesRef.current);
+      setConversationId(created.id);
+      setActiveConversationId(created.id);
+    }
+
+    if (requestedId) {
+      window.history.replaceState(null, "", window.location.pathname);
+    }
+  }, [
+    isConversationsLoaded,
+    activeConversationId,
+    getConversation,
+    createConversation,
+    setActiveConversationId,
+  ]);
+
+  // メッセージが変化するたびに現在の会話をLocalStorageへ自動保存する
+  useEffect(() => {
+    if (!conversationId) return;
+    saveMessages(conversationId, messages);
+    // saveMessagesはContextの再レンダリングのたびに参照が変わるため、
+    // 依存配列に含めると無限ループになる。messages変化時のみ実行する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversationId, messages]);
+
+  // 現在の会話を保存した上で、新しい会話を開始する
+  const handleNewConversation = useCallback(() => {
+    const initialMessages = createInitialMessages();
+    const created = createConversation(initialMessages);
+    setMessages(initialMessages);
+    setConversationId(created.id);
+    setActiveConversationId(created.id);
+    setCurrentNewsIndex(0);
+    setDetectedLanguage("");
+    setShowSettingsMenu(false);
+  }, [createConversation, setActiveConversationId]);
 
   // Auto-play TTS for user message translations when autoPlayAudio is enabled
   useEffect(() => {
@@ -1489,6 +1545,14 @@ export default function ChatUI() {
               {/* Settings menu items - slide up animation */}
               {showSettingsMenu && (
                 <div className="absolute bottom-16 right-0 flex flex-col gap-2 animate-slide-up">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-12 w-12 p-0 shadow-md"
+                    onClick={handleNewConversation}
+                  >
+                    <MessageSquarePlus className="h-5 w-5" />
+                  </Button>
                   <Button
                     variant={autoPlayAudio ? "default" : "outline"}
                     size="sm"

--- a/apps/web/lib/conversation-context.tsx
+++ b/apps/web/lib/conversation-context.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useReducer, useState } from "react";
+
+// チャット画面で使用するメッセージ型（page.tsxと共通で使用する）
+export interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  correctedContent?: string;
+  translatedContent?: string;
+  timestamp: string;
+  type?: "news" | "chat";
+  currentIndex?: number;
+  totalStories?: number;
+  originalContent?: string;
+}
+
+// 会話1件分のデータ
+export interface Conversation {
+  id: string;
+  title: string;
+  messages: Message[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+type ConversationAction =
+  | { type: "LOAD_CONVERSATIONS"; payload: Conversation[] }
+  | { type: "UPSERT_CONVERSATION"; payload: Conversation }
+  | { type: "DELETE_CONVERSATION"; payload: string };
+
+interface ConversationState {
+  conversations: Conversation[];
+  // LocalStorageからの初期読み込みが完了したかどうか
+  // （SSRとの水和ミスマッチを避けるため、初期状態は必ず空配列にしている）
+  isLoaded: boolean;
+}
+
+interface ConversationContextType extends ConversationState {
+  activeConversationId: string | null;
+  setActiveConversationId: (id: string | null) => void;
+  createConversation: (messages: Message[]) => Conversation;
+  saveMessages: (id: string, messages: Message[]) => void;
+  deleteConversation: (id: string) => void;
+  getConversation: (id: string) => Conversation | undefined;
+}
+
+function conversationReducer(
+  state: ConversationState,
+  action: ConversationAction
+): ConversationState {
+  switch (action.type) {
+    case "LOAD_CONVERSATIONS":
+      return { conversations: action.payload, isLoaded: true };
+    case "UPSERT_CONVERSATION": {
+      const exists = state.conversations.some(
+        (conversation) => conversation.id === action.payload.id
+      );
+      return {
+        ...state,
+        conversations: exists
+          ? state.conversations.map((conversation) =>
+              conversation.id === action.payload.id
+                ? action.payload
+                : conversation
+            )
+          : [action.payload, ...state.conversations],
+      };
+    }
+    case "DELETE_CONVERSATION":
+      return {
+        ...state,
+        conversations: state.conversations.filter(
+          (conversation) => conversation.id !== action.payload
+        ),
+      };
+    default:
+      return state;
+  }
+}
+
+const STORAGE_KEY = "lingua-chat-conversations";
+const ACTIVE_ID_STORAGE_KEY = "lingua-chat-active-conversation-id";
+const DEFAULT_TITLE = "新しい会話";
+
+const loadFromLocalStorage = (): Conversation[] => {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? JSON.parse(saved) : [];
+  } catch (error) {
+    console.error("LocalStorageからの会話履歴読み込みエラー:", error);
+    return [];
+  }
+};
+
+const saveToLocalStorage = (conversations: Conversation[]): void => {
+  if (typeof window === "undefined") return;
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(conversations));
+  } catch (error) {
+    console.error("LocalStorageへの会話履歴保存エラー:", error);
+  }
+};
+
+const loadActiveIdFromLocalStorage = (): string | null => {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(ACTIVE_ID_STORAGE_KEY);
+};
+
+// タイトル未設定の会話用に、最初のユーザー発言からタイトルを生成する
+const buildTitleFromMessages = (messages: Message[]): string => {
+  const firstUserMessage = messages.find((message) => message.role === "user");
+  const source = firstUserMessage?.content.trim() || DEFAULT_TITLE;
+  return source.length > 20 ? `${source.slice(0, 20)}…` : source;
+};
+
+const ConversationContext = createContext<ConversationContextType | undefined>(
+  undefined
+);
+
+export function ConversationProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // 初期状態はSSRと同じ空配列にしておき、マウント後にLocalStorageから読み込む
+  // （水和ミスマッチを避けるため。bookmark-context.tsxと同じ方針）
+  const [state, dispatch] = useReducer(conversationReducer, {
+    conversations: [],
+    isLoaded: false,
+  });
+  const [activeConversationId, setActiveConversationIdState] = useState<
+    string | null
+  >(loadActiveIdFromLocalStorage);
+
+  useEffect(() => {
+    dispatch({ type: "LOAD_CONVERSATIONS", payload: loadFromLocalStorage() });
+  }, []);
+
+  // 読み込み完了後、会話一覧が変わるたびにLocalStorageへ保存する
+  useEffect(() => {
+    if (!state.isLoaded) return;
+    saveToLocalStorage(state.conversations);
+  }, [state.isLoaded, state.conversations]);
+
+  const setActiveConversationId = (id: string | null) => {
+    setActiveConversationIdState(id);
+    if (typeof window === "undefined") return;
+    if (id) {
+      localStorage.setItem(ACTIVE_ID_STORAGE_KEY, id);
+    } else {
+      localStorage.removeItem(ACTIVE_ID_STORAGE_KEY);
+    }
+  };
+
+  const contextValue: ConversationContextType = {
+    ...state,
+    activeConversationId,
+    setActiveConversationId,
+    createConversation: (messages: Message[]) => {
+      const now = new Date().toISOString();
+      const conversation: Conversation = {
+        id: `conversation-${Date.now()}`,
+        title: buildTitleFromMessages(messages),
+        messages,
+        createdAt: now,
+        updatedAt: now,
+      };
+      dispatch({ type: "UPSERT_CONVERSATION", payload: conversation });
+      return conversation;
+    },
+    saveMessages: (id: string, messages: Message[]) => {
+      const existing = state.conversations.find(
+        (conversation) => conversation.id === id
+      );
+      const now = new Date().toISOString();
+      const conversation: Conversation = {
+        id,
+        title:
+          existing?.title && existing.title !== DEFAULT_TITLE
+            ? existing.title
+            : buildTitleFromMessages(messages),
+        messages,
+        createdAt: existing?.createdAt || now,
+        updatedAt: now,
+      };
+      dispatch({ type: "UPSERT_CONVERSATION", payload: conversation });
+    },
+    deleteConversation: (id: string) => {
+      dispatch({ type: "DELETE_CONVERSATION", payload: id });
+      if (activeConversationId === id) {
+        setActiveConversationId(null);
+      }
+    },
+    getConversation: (id: string) =>
+      state.conversations.find((conversation) => conversation.id === id),
+  };
+
+  return (
+    <ConversationContext.Provider value={contextValue}>
+      {children}
+    </ConversationContext.Provider>
+  );
+}
+
+export function useConversation() {
+  const context = useContext(ConversationContext);
+  if (context === undefined) {
+    throw new Error("useConversationはConversationProvider内で使用してください");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- `ConversationProvider`（`lib/conversation-context.tsx`）を新設し、`bookmark-context.tsx`と同じReact Context + LocalStorageのパターンで会話履歴を永続化
- チャット画面（`app/page.tsx`）でメッセージ変化を自動保存し、起動時に直前の会話（またはURLの`?conversation=<id>`）を復元。設定メニューに「新しい会話」ボタンを追加
- 既にナビゲーションからリンクされていた`/history`ページを新規実装し、過去の会話一覧の閲覧・再開・削除に対応
- 設計判断をADR（`apps/docs/adr/0052-conversation-history-local-storage.md`）に記録

## Test plan
- [x] `tsc --noEmit` で型チェックがパスすることを確認
- [x] `next lint --max-warnings 0` で新規/変更ファイルに警告が無いことを確認
- [x] Playwrightでdevサーバー上の動作確認: メッセージ送信→LocalStorageへの会話保存、`/history`一覧表示、会話クリックで復元、リロード後も会話が保持されること、「新しい会話」ボタンでの新規作成、履歴からの削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h)_