### PR TITLE
Fix AI replying in Japanese in ongoing conversations

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -399,10 +399,13 @@ export default function ChatUI() {
     try {
       setIsAIResponding(true);
 
-      const conversationHistory = [
+      const conversationHistory: Pick<
+        Message,
+        "role" | "content" | "translatedContent"
+      >[] = [
         ...messages,
         {
-          role: "user" as const,
+          role: "user",
           content: userMessage,
         },
       ];
@@ -413,9 +416,12 @@ export default function ChatUI() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          // 日本語入力のユーザーメッセージは英訳(translatedContent)を使う。
+          // ここでcontent（原文の日本語）を送ると会話履歴に日本語が混ざり、
+          // AIが英語ではなく日本語で返答してしまう不具合があった
           messages: conversationHistory.map((msg) => ({
             role: msg.role,
-            content: msg.content,
+            content: msg.translatedContent || msg.content,
           })),
         }),
       });


### PR DESCRIPTION
## Summary
- `generateAIResponse`が`/api/chat`へ会話履歴を送る際、日本語入力のユーザーメッセージが`content`（原文の日本語）のまま送られており、`translatedContent`（英訳）が使われていなかった
- 会話が進むにつれて履歴に日本語が混ざり、AIが英語ではなく日本語で返答してしまう不具合があった
- 履歴構築時に`msg.translatedContent || msg.content`を使うよう修正し、常に英語の履歴がAPIへ送られるようにした

## Test plan
- [x] `tsc --noEmit` で型チェックがパスすることを確認
- [x] `next lint --max-warnings 0` で警告が無いことを確認
- [x] 修正後のマッピングロジックを単体で実行し、日本語原文ではなく英訳が履歴に反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h)_