### PR TITLE
Fix loading indicator causing footer height to shift

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1459,6 +1459,26 @@ export default function ChatUI() {
               </div>
             </div>
           ))}
+
+          {/* AI応答生成中のタイピングインジケーター（フッターの高さを変えないよう吹き出しで表現） */}
+          {isAIResponding && (
+            <div className="flex justify-start">
+              <div className="flex max-w-[80%] flex-row">
+                <div className="flex flex-col items-start">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="font-semibold text-gray-900">Bob</span>
+                  </div>
+                  <div className="rounded-lg p-4 bg-gray-50">
+                    <div className="flex items-center gap-1.5">
+                      <span className="h-2 w-2 rounded-full bg-gray-400 animate-bounce [animation-delay:-0.3s]" />
+                      <span className="h-2 w-2 rounded-full bg-gray-400 animate-bounce [animation-delay:-0.15s]" />
+                      <span className="h-2 w-2 rounded-full bg-gray-400 animate-bounce" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       </div>
 
@@ -1608,16 +1628,14 @@ export default function ChatUI() {
             </div>
           </div>
         </div>
-        {isTranscribing && (
-          <p className="text-center text-sm text-blue-600 mt-3 animate-pulse">
-            Analyzing voice... / 音声を解析中...
-          </p>
-        )}
-        {detectedLanguage &&
-          !isRecording &&
-          !isTranscribing &&
-          !isAIResponding && (
-            <p className="text-center text-xs text-gray-500 mt-1">
+        {/* 状態表示は高さ固定のスロットにまとめ、表示/非表示でフッターの高さが変わらないようにする */}
+        <div className="mt-3 flex items-center justify-center h-5">
+          {isTranscribing ? (
+            <p className="text-sm text-blue-600 animate-pulse">
+              Analyzing voice... / 音声を解析中...
+            </p>
+          ) : detectedLanguage && !isRecording && !isAIResponding ? (
+            <p className="text-xs text-gray-500">
               Detected:{" "}
               {detectedLanguage === "japanese"
                 ? "日本語"
@@ -1625,12 +1643,8 @@ export default function ChatUI() {
                   ? "English"
                   : detectedLanguage}
             </p>
-          )}
-        {isAIResponding && (
-          <p className="text-center text-sm text-blue-600 mt-3 animate-pulse">
-            AI generating response... / AI が回答を生成中...
-          </p>
-        )}
+          ) : null}
+        </div>
       </div>
 
       {showSpeedControl && (


### PR DESCRIPTION
## Summary
- AI応答生成中・音声認識中のステータステキストがフッター下部に条件付きで表示されており、表示/非表示の切り替えでフッターの高さが変わってレイアウトがガタつく問題があった
- AI応答生成中は、フッターのテキストではなくチャットのメッセージ一覧内に「入力中」を表すタイピングインジケーター（バウンドする3つのドット）の吹き出しを表示するように変更
- 音声認識中・検出言語の表示は、常に一定の高さを確保したステータス欄にまとめ、内容の有無に関わらずフッターの高さが変わらないようにした

## Test plan
- [x] `tsc --noEmit` で型チェックがパスすることを確認
- [x] `next lint --max-warnings 0` で警告が無いことを確認
- [x] Playwrightでメッセージ送信前後・応答生成中のフッター高さを継続的に計測し、常に同じ高さ(161px)であることを確認
- [x] 応答生成中にチャット欄内へタイピングインジケーターが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h)_