### PR TITLE
Auto-scroll to the newest message when one is added

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -666,6 +666,21 @@ export default function ChatUI() {
     return () => resizeObserver.disconnect();
   }, []);
 
+  // 新規メッセージが追加された時だけ最下部へ自動スクロールする
+  // （修正・翻訳結果を既存メッセージへ後から差し込む更新では件数が変わらないため発火しない）
+  const prevMessagesLengthRef = useRef(messages.length);
+  useEffect(() => {
+    if (messages.length > prevMessagesLengthRef.current) {
+      const container = messagesContainerRef.current;
+      if (container) {
+        requestAnimationFrame(() => {
+          container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
+        });
+      }
+    }
+    prevMessagesLengthRef.current = messages.length;
+  }, [messages]);
+
   // 会話履歴の初期化: LocalStorageの読み込み完了を待ってから、
   // URLの?conversation=<id>、なければ直前に開いていた会話、
   // どちらもなければ新規会話を復元・作成する（一度だけ実行）


### PR DESCRIPTION
## Summary
- メッセージ一覧に自動スクロールの仕組みが無く、途中までスクロールした状態でメッセージを送信・受信しても新しいメッセージが画面外に留まっていた
- メッセージの件数が増えたタイミング（新規メッセージ追加時）にのみ最下部へスムーズスクロールするようにした
- 英文修正・翻訳結果を既存メッセージへ後から差し込む更新（件数は変わらない）では発火しないようにしている

## Test plan
- [x] `tsc --noEmit` で型チェックがパスすることを確認
- [x] `next lint --max-warnings 0` で警告が無いことを確認
- [x] Playwrightで、あえて一覧の先頭までスクロールした状態からメッセージを送信し、送信後は最下部付近まで自動的にスクロールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h)_