### PR TITLE
Add manual phrase entry to the saved-phrases page

### DIFF
--- a/apps/docs/adr/0054-manual-phrase-add-from-saved-phrases.md
+++ b/apps/docs/adr/0054-manual-phrase-add-from-saved-phrases.md
@@ -1,0 +1,95 @@
+# 0054 – 保存したフレーズ画面からの手動フレーズ追加機能
+
+## 背景 / Context
+
+これまでフレーズの保存は、チャット画面でメッセージをブックマークする経路でしか行えなかった。チャットで会話していない単語・表現でも「保存したフレーズ」に直接登録したいというニーズがあり、一覧画面単体で完結する追加手段が求められていた。
+
+---
+
+## 決定 / Decision
+
+`/saved-phrases`画面右下にフローティングの追加ボタン（+）を設置し、タップすると英語フレーズ（必須）と日本語訳（任意）を入力できる小さなフォームを表示する。保存すると`bookmark-context.tsx`の`addBookmark`を通じて既存のブックマークと同じLocalStorageに永続化される。
+
+---
+
+## 理由 / Rationale
+
+- 既存のブックマーク機能（Context + LocalStorage）をそのまま再利用でき、データの持ち方を分岐させずに済む
+- チャット画面の「テキスト入力」ポップアップと同じUIパターン（右下のボタン→吹き出し型フォーム）を踏襲し、実装コストと学習コストを抑える
+- 日本語訳を任意項目にすることで、英単語だけを素早くメモしたい場合にも対応できる
+
+---
+
+## 実装詳細 / Implementation Notes
+
+### 1. 手動追加用のSavedPhrase生成
+
+```tsx
+// app/saved-phrases/page.tsx
+const handleAddPhrase = () => {
+  const englishContent = newPhraseEnglish.trim();
+  if (!englishContent) return;
+
+  addBookmark({
+    id: `manual-${Date.now()}`,
+    content: englishContent,
+    category: "bookmark",
+    timestamp: new Date().toLocaleString("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }),
+    originalContent: newPhraseJapanese.trim() || undefined,
+  });
+
+  handleCloseAddForm();
+};
+```
+
+理由:
+
+- IDに`manual-`プレフィックスを付け、チャット由来の`bookmark-${messageId}`と衝突しないようにした
+- `category: "bookmark"`固定にすることで、既存の`getBookmarkedPhrases`のフィルタ条件をそのまま満たす
+- 日本語訳が未入力の場合は`undefined`にし、表示側の`phrase.originalContent &&`という既存の条件分岐をそのまま利用できるようにした
+
+### 2. フローティングボタンとフォームUI
+
+```tsx
+<Button
+  onClick={() => setShowAddForm(!showAddForm)}
+  size="lg"
+  className="h-14 w-14 rounded-full p-0 shadow-lg bg-blue-500 hover:bg-blue-600"
+>
+  <Plus className="h-6 w-6 text-white" />
+</Button>
+```
+
+理由:
+
+- チャット画面のテキスト入力ポップアップ（`app/page.tsx`）と同じ吹き出し型フォームのスタイルを流用し、アプリ内での見た目の一貫性を保った
+- 英語フレーズが未入力の場合は保存ボタンを無効化し、空データの登録を防止
+
+---
+
+## 影響 / Consequences
+
+- チャットを経由せずに、保存したフレーズ画面から直接フレーズを追加できるようになる
+- 既存のブックマークデータ構造・LocalStorageキーは変更していないため、既存データへの影響はない
+
+---
+
+## 言語的・技術的なポイント
+
+- 既存Contextの`addBookmark`をそのまま呼び出すだけで永続化・一覧反映の両方が完結する設計になっているため、新規追加経路を増やす際の変更範囲が最小限で済んだ
+
+---
+
+## 参考 / References
+
+- 0039-bookmark-page-implementation.md - 保存したフレーズ画面の基礎実装
+- 0041-bookmark-integration-localstorage-persistence.md - Context + LocalStorageによる永続化パターン
+
+---

--- a/apps/web/app/saved-phrases/page.tsx
+++ b/apps/web/app/saved-phrases/page.tsx
@@ -4,12 +4,15 @@ import React, { useState, useCallback } from "react";
 import { useBookmark } from "@/lib/bookmark-context";
 import { ttsPlayer } from "@/lib/audio-player";
 import { Button } from "@/components/ui/button";
-import { Trash2, Copy, Volume2, VolumeX, Bookmark } from "lucide-react";
+import { Trash2, Copy, Volume2, VolumeX, Bookmark, Plus, X } from "lucide-react";
 
 export default function SavedPhrasesPage() {
-  const { savedPhrases, removeBookmark } = useBookmark();
+  const { savedPhrases, addBookmark, removeBookmark } = useBookmark();
   const [isPlaying, setIsPlaying] = useState<Record<string, boolean>>({});
   const [playbackSpeed] = useState(1.0); // 固定速度で実装
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newPhraseEnglish, setNewPhraseEnglish] = useState("");
+  const [newPhraseJapanese, setNewPhraseJapanese] = useState("");
 
   // ブックマーク関連のフレーズを取得（過去の修正・翻訳も含む）
   const bookmarkedPhrases = savedPhrases;
@@ -20,6 +23,34 @@ export default function SavedPhrasesPage() {
 
   const handleCopy = (content: string) => {
     navigator.clipboard.writeText(content);
+  };
+
+  const handleCloseAddForm = () => {
+    setShowAddForm(false);
+    setNewPhraseEnglish("");
+    setNewPhraseJapanese("");
+  };
+
+  const handleAddPhrase = () => {
+    const englishContent = newPhraseEnglish.trim();
+    if (!englishContent) return;
+
+    addBookmark({
+      id: `manual-${Date.now()}`,
+      content: englishContent,
+      category: "bookmark",
+      timestamp: new Date().toLocaleString("ja-JP", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      }),
+      originalContent: newPhraseJapanese.trim() || undefined,
+    });
+
+    handleCloseAddForm();
   };
 
   const handleTextToSpeech = useCallback(
@@ -137,6 +168,81 @@ export default function SavedPhrasesPage() {
             ))}
           </div>
         )}
+      </div>
+
+      {/* 新規フレーズ追加ボタン */}
+      <div className="fixed bottom-6 right-6 z-20">
+        <div className="relative">
+          {showAddForm && (
+            <div className="absolute bottom-16 right-0 mb-2 p-4 bg-white border border-gray-200 rounded-lg shadow-lg w-80">
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-gray-700">
+                    フレーズを追加
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0"
+                    onClick={handleCloseAddForm}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs text-gray-500">
+                    日本語（任意）
+                  </label>
+                  <input
+                    type="text"
+                    value={newPhraseJapanese}
+                    onChange={(e) => setNewPhraseJapanese(e.target.value)}
+                    placeholder="でも、かろうじてポテチ買ってある。"
+                    className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs text-gray-500">英語フレーズ</label>
+                  <textarea
+                    value={newPhraseEnglish}
+                    onChange={(e) => setNewPhraseEnglish(e.target.value)}
+                    placeholder="But I barely managed to buy some potato chips."
+                    className="w-full p-2 border border-gray-300 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    rows={2}
+                    autoFocus
+                  />
+                </div>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCloseAddForm}
+                  >
+                    キャンセル
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={handleAddPhrase}
+                    disabled={!newPhraseEnglish.trim()}
+                    className="bg-blue-500 hover:bg-blue-600"
+                  >
+                    保存
+                  </Button>
+                </div>
+              </div>
+              {/* Arrow pointing down */}
+              <div className="absolute -bottom-2 right-4 w-4 h-4 bg-white border-r border-b border-gray-200 transform rotate-45"></div>
+            </div>
+          )}
+
+          <Button
+            onClick={() => setShowAddForm(!showAddForm)}
+            size="lg"
+            className="h-14 w-14 rounded-full p-0 shadow-lg bg-blue-500 hover:bg-blue-600"
+          >
+            <Plus className="h-6 w-6 text-white" />
+          </Button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- これまでフレーズの保存はチャット画面でのブックマーク経由でしかできなかったが、`/saved-phrases`画面右下に追加ボタン（+）を新設し、一覧画面から直接フレーズを追加できるようにした
- 追加フォームでは英語フレーズ（必須）と日本語訳（任意）を入力でき、保存すると既存の`bookmark-context.tsx`の`addBookmark`を通じて同じLocalStorageに永続化される
- チャット・履歴どちらの一覧にも表示され、コピー・読み上げ・削除など既存の操作がそのまま使える
- 設計判断を`apps/docs/adr/0054-manual-phrase-add-from-saved-phrases.md`に記録

## Test plan
- [x] `tsc --noEmit` で型チェックがパスすることを確認
- [x] `next lint --max-warnings 0` で警告が無いことを確認
- [x] Playwrightで、追加ボタン→フォーム入力→保存の流れでLocalStorageに正しく保存され、一覧にも表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h)_