### PR TITLE
Fix iOS auto-zoom when opening the add-phrase form

### DIFF
--- a/apps/web/app/saved-phrases/page.tsx
+++ b/apps/web/app/saved-phrases/page.tsx
@@ -198,7 +198,7 @@ export default function SavedPhrasesPage() {
                     value={newPhraseJapanese}
                     onChange={(e) => setNewPhraseJapanese(e.target.value)}
                     placeholder="でも、かろうじてポテチ買ってある。"
-                    className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   />
                 </div>
                 <div className="space-y-1">
@@ -207,7 +207,7 @@ export default function SavedPhrasesPage() {
                     value={newPhraseEnglish}
                     onChange={(e) => setNewPhraseEnglish(e.target.value)}
                     placeholder="But I barely managed to buy some potato chips."
-                    className="w-full p-2 border border-gray-300 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    className="w-full p-2 border border-gray-300 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     rows={2}
                     autoFocus
                   />


### PR DESCRIPTION
## Summary
- 保存したフレーズ画面の追加フォーム（日本語入力・英語フレーズ入力）が`text-sm`(14px)を指定していた
- iOS Safariはフォーム要素のフォントサイズが16px未満だとフォーカス時に自動でページを拡大する仕様があり、これが「追加ボタンをタップすると画面が勝手に拡大される」原因だった
- `text-sm`指定を外し、両フィールドをデフォルトの16pxで表示するようにした

## Test plan
- [x] `tsc --noEmit` で型チェックがパスすることを確認
- [x] `next lint --max-warnings 0` で警告が無いことを確認
- [x] Playwrightで両フィールドの`computed font-size`が16pxになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kinDHCdvcTMMWsdkie6h)_